### PR TITLE
Rule to find past members does is >30days, not >=30days

### DIFF
--- a/src/Model/Table/MembersTable.php
+++ b/src/Model/Table/MembersTable.php
@@ -171,7 +171,7 @@ class MembersTable extends Table
         $maxDate = date_format(new \DateTime("- $daysBeforeToday days"), 'Y-m-d');
         
         $query->notMatching('Memberships', function ($q) use ($maxDate) {
-            return $q->where(['Memberships.expires_on >=' => $maxDate]);
+            return $q->where(['Memberships.expires_on >' => $maxDate]);
         });
         
         return $query;


### PR DESCRIPTION
- [x] Tested tamarin on heroku; user was unsubscribed after 30 days, but received no emails. Later either the administrators or the person herself could receive an email notice when unsubscribed.
- [x] "export past members" now includes those who expired 30 days ago (before only >30), to match rule that ubsubscribes them on mailchimp
