### PR TITLE
Add growth statistics behavior

### DIFF
--- a/src/Controller/Admin/DashboardsController.php
+++ b/src/Controller/Admin/DashboardsController.php
@@ -22,6 +22,20 @@ class DashboardsController extends AppController
         $allMembers = $this->Members->find('all');
         $activeMembers = $this->Members->find('activeMembers');
         $newMembers = $this->Members->find('newMembers');
+
+        $statsParams = [
+            'stats' => [
+                'field' => 'created',
+                'referenceDate' => 'today',
+                'dates' => ['-1 month', '-1 year']
+            ]
+        ];
+
+        $allMembersGrowth = $this->Members->find('countGrowth', $statsParams);
+
+        // Need to fix new members query
+        $newMembersGrowth = $this->Members->find('newMembers')->find('countGrowth', $statsParams);
+
         // $soonToExpireMembers = $this->Members->find('soonToExpireMembers');
         $recentlyDeactivatedMembers = $this->Members
             ->find('limboMembers')
@@ -38,6 +52,6 @@ class DashboardsController extends AppController
         // $metrics['averageAge'] = $this->Members->find('averageAge')->count();
         // $metrics['mostCommonJob'] = $this->Members->find('mostCommonJob')->count();
 
-        $this->set(compact('metrics', 'allMembers', 'activeMembers', 'newMembers', 'recentlyDeactivatedMembers'));
+        $this->set(compact('allMembersGrowth', 'newMembersGrowth', 'metrics', 'allMembers', 'activeMembers', 'newMembers', 'recentlyDeactivatedMembers'));
     }
 }

--- a/src/Model/Behavior/GrowthStatisticsBehavior.php
+++ b/src/Model/Behavior/GrowthStatisticsBehavior.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Model\Behavior;
+
+use Cake\ORM\Behavior;
+use Cake\ORM\Query;
+
+class GrowthStatisticsBehavior extends Behavior
+{
+	public function calculateGrowth($finalValue, $startValue) {
+		if ($startValue <= 0) {
+			return 100;
+		}
+		if (is_numeric($finalValue) && is_numeric($startValue)) {
+			return (($finalValue - $startValue) / $startValue) * 100;
+		}
+		return -1;
+	}
+
+	// As options:
+	// stats
+	//   field => 'created'
+	//   referenceDate => 'today'
+	//   dates => ["-1 month", "-1 year"]
+	public function findCountGrowth(Query $query, array $options)
+	{
+
+		$stats = array();
+
+		if ($options['stats'] && $options['stats']['field'] && $options['stats']['dates']) {
+			$field = $options['stats']['field'];
+
+			// Growth reference data
+			if ($options['stats']['referenceDate']) {
+				$referenceDate = new \DateTime($options['stats']['referenceDate']);
+			}
+			else {
+				$referenceDate = new \DateTime();
+			}
+			
+			$referenceDateFormatted = date_format($referenceDate, 'Y-m-d');
+
+			$referenceQuery = $query->where([
+				$field . ' <= ' => $referenceDateFormatted
+			]);
+			$referenceCount = $referenceQuery->count();
+			$stats["reference"] = [
+				"count" => $referenceCount,
+				"growth" => 0,
+				"data" => $referenceQuery->toArray()
+			];			
+
+			// Comparisons
+			foreach ($options['stats']['dates'] as $gDate) {
+				$comparisonDate = date_add($referenceDate, date_interval_create_from_date_string($gDate));
+
+				$dateQuery = $query->where([
+					$field . ' <= ' => date_format($comparisonDate, 'Y-m-d')
+				]);
+
+				$count = $dateQuery->count();
+				$stats[$gDate] = [
+					"count" => $count,
+					"growth" => $this->calculateGrowth($referenceCount, $count),
+					"data" => $dateQuery->toArray()
+				];
+			}
+		}
+	    return $stats;
+	}
+}

--- a/src/Model/Table/MembersTable.php
+++ b/src/Model/Table/MembersTable.php
@@ -34,6 +34,7 @@ class MembersTable extends Table
         $this->primaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('GrowthStatistics');
 
         $this->hasMany('Memberships', [
             'foreignKey' => 'member_id'

--- a/src/Template/Admin/Dashboards/index.ctp
+++ b/src/Template/Admin/Dashboards/index.ctp
@@ -26,9 +26,16 @@
                     <h5><?= __('Registered members') ?></h5>
                 </div>
                 <div class="ibox-content">
-                    <h1 class="no-margins"><?= $metrics['numRegisteredMembers'] ?></h1>
-                    <div class="stat-percent font-bold text-success">98% <i class="fa fa-bolt"></i></div>
-                    <small><?= __('Members registered') ?></small>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h1 class="no-margins"><?= $allMembersGrowth['reference']['count'] ?></h1>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="stat-percent font-bold text-info"><?= number_format($allMembersGrowth['-1 month']['growth'], 0) ?>% <i class="fa fa-level-up"></i> <small> <?= __('last month') ?></small></div>
+                            <div class="font-bold text-navy"><?= number_format($allMembersGrowth['-1 year']['growth'], 0) ?>% <i class="fa fa-level-up"></i> <small> <?= __('last year') ?></small></div>
+                        </div>
+                    </div>
+                    <small><?= __('members registered') ?></small>
                 </div>
             </div>
         </div>
@@ -97,15 +104,15 @@
                 <div class="ibox-content">
                     <div class="row">
                         <div class="col-sm-4">
-                            <h1 class="no-margins"><?= $metrics['numNewMembers'] ?></h1>
+                            <h1 class="no-margins"><?= $newMembersGrowth['reference']['count'] ?></h1>
                             <small><?= __('members') ?></small>
                         </div>
                         <div class="col-sm-8">
                             <div class="row">
-                                <div class="stat-percent font-bold text-navy">2% <i class="fa fa-level-up"></i> <small> <?= __('last month') ?></small></div>
+                                <div class="stat-percent font-bold text-navy"><?= number_format($newMembersGrowth['-1 month']['growth'], 0) ?>%  <i class="fa fa-level-up"></i> <small> <?= __('last month') ?></small></div>
                             </div>
                             <div class="row">
-                                <div class="stat-percent font-bold text-info">44% <i class="fa fa-level-up"></i> <small> <?= __('last year') ?></small></div>
+                                <div class="stat-percent font-bold text-info"><?= number_format($newMembersGrowth['-1 month']['growth'], 0) ?>%  <i class="fa fa-level-up"></i> <small> <?= __('last year') ?></small></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
https://github.com/LordAlexWorks/tamarin/issues/24  Dashboard with information and statistics
- [x] Created behavior for any table model, called GrowthStatistics
- [x] statistics of registered members
- [ ] started statistics of new members, but it's considering the new members of the current month for all "current" (14), "-1 year" (0) and "-1 month" (0), so the growth is 100%. Need to adjust so that the query takes always the new members of the query's date.
