### PR TITLE
Improved dashboard, created membership initial date

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Once a list is created in mailchimp, the user can create email campaigns directl
 * **Subscribe**: a member is subscribed in the mailchimp list when their first membership is created.
   * S/he does not receive any automatic emails, and does not need to confirm subscription.
 * **Data**:
-  * Currently we store in the list: `First name`, `Last name`, and `Expires on`, besides the email. Only `Expires on` is updated, the other data (including email) does not change even when the member updates a profile.
-  * The `Expires on` field is updated whenever the membership is updated, for future or past dates.
+  * Currently we store in the list: `First name`, `Last name`, `Starts on`, and `Expires on`, besides the email. Only `Starts on` and `Expires on` are updated, the other data (including email) does not change even when the member updates her/his profile.
+  * The `Starts on` and `Expires on` fields are updated whenever the membership is updated, for future or past dates.
 * **Unsubscribe**: a member is unsubscribed automatically 30 days after their last membership expired.
   * The user and her/his data remains in the list, under a different category ("Unsubscribed").

--- a/src/Controller/Admin/DashboardsController.php
+++ b/src/Controller/Admin/DashboardsController.php
@@ -9,6 +9,8 @@ use App\Controller\AppController;
  */
 class DashboardsController extends AppController
 {
+    public $helpers = ['Statistics'];
+
     /**
      * Index method
      *
@@ -18,40 +20,58 @@ class DashboardsController extends AppController
     {
         $this->loadModel('Members');
 
-        // Lists
-        $allMembers = $this->Members->find('all');
-        $activeMembers = $this->Members->find('activeMembers');
-        $newMembers = $this->Members->find('newMembers');
-
         $statsParams = [
             'stats' => [
                 'field' => 'created',
-                'referenceDate' => 'today',
                 'dates' => ['-1 month', '-1 year']
             ]
         ];
 
         $allMembersGrowth = $this->Members->find('countGrowth', $statsParams);
 
-        // Need to fix new members query
-        $newMembersGrowth = $this->Members->find('newMembers')->find('countGrowth', $statsParams);
+        // New members
+        $newMembersParams = [ 'stats' => [ 'customFinder' => 'newMembers' ] ];
+        $newMembersGrowth = $this->Members->find(
+            'countGrowth',
+            array_merge_recursive($statsParams, $newMembersParams)
+        );
 
-        // $soonToExpireMembers = $this->Members->find('soonToExpireMembers');
+        $newMembers = $this->Members->find('newMembers')
+            ->order(['Members.created' => 'DESC']);
+
+        // Soon to deactivate
+        $soonToDeactivateParams = [ 'stats' => [ 'customFinder' => 'soonToDeactivateMembers' ] ];
+        $soonToDeactivateGrowth = $this->Members->find(
+            'countGrowth',
+            array_merge_recursive($statsParams, $soonToDeactivateParams)
+        );
+
+        $soonToDeactivateMembers = $this->Members
+            ->find('soonToDeactivateMembers');
+        
+        // Recently deactivated
+        $recentlyDeactivatedParams = [ 'stats' => [ 'customFinder' => 'recentlyDeactivatedMembers' ] ];
+        $recentlyDeactivatedGrowth = $this->Members->find(
+            'countGrowth',
+            array_merge_recursive($statsParams, $recentlyDeactivatedParams)
+        );
+
         $recentlyDeactivatedMembers = $this->Members
-            ->find('limboMembers')
-            ->contain(['Memberships' => [
-                'sort' => ['expires_on' => 'DESC']
-            ]]);
-
-        // Numeric metrics
-        $metrics['numRegisteredMembers'] = $allMembers->count();
-        $metrics['numActiveMembers'] = $activeMembers->count();
-        $metrics['numNewMembers'] = $newMembers->count();
-        $metrics['numRecentlyDeactivatedMembers'] = $recentlyDeactivatedMembers->count();
+            ->find('recentlyDeactivatedMembers')
+            ->contain(['Memberships'])
+            ->order(['Memberships.expires_on' => 'DESC']);
 
         // $metrics['averageAge'] = $this->Members->find('averageAge')->count();
         // $metrics['mostCommonJob'] = $this->Members->find('mostCommonJob')->count();
 
-        $this->set(compact('allMembersGrowth', 'newMembersGrowth', 'metrics', 'allMembers', 'activeMembers', 'newMembers', 'recentlyDeactivatedMembers'));
+        $this->set(compact(
+            'allMembersGrowth',
+            'newMembers',
+            'newMembersGrowth',
+            'soonToDeactivateMembers',
+            'soonToDeactivateGrowth',
+            'recentlyDeactivatedMembers',
+            'recentlyDeactivatedGrowth'
+        ));
     }
 }

--- a/src/Controller/Admin/MembersController.php
+++ b/src/Controller/Admin/MembersController.php
@@ -60,9 +60,9 @@ class MembersController extends AppController
             }
         }
 
-        $defaultMembershipDate = $this->Members->Memberships->getDefaultMembershipDate();
-        $this->set(compact('member', 'defaultMembershipDate'));
-        $this->set('_serialize', ['member', 'defaultMembershipDate']);
+        $membershipDefaultExpiration = $this->Members->Memberships->getMembershipDefaultExpiration();
+        $this->set(compact('member', 'membershipDefaultExpiration'));
+        $this->set('_serialize', ['member', 'membershipDefaultExpiration']);
         $this->viewBuilder()->template('add_edit_common');
     }
 
@@ -92,9 +92,9 @@ class MembersController extends AppController
             }
         }
         
-        $defaultMembershipDate = $this->Members->Memberships->getDefaultMembershipDate();
-        $this->set(compact('member', 'defaultMembershipDate'));
-        $this->set('_serialize', ['member', 'defaultMembershipDate']);
+        $membershipDefaultExpiration = $this->Members->Memberships->getMembershipDefaultExpiration();
+        $this->set(compact('member', 'membershipDefaultExpiration'));
+        $this->set('_serialize', ['member', 'membershipDefaultExpiration']);
         $this->viewBuilder()->template('add_edit_common');
     }
 
@@ -210,11 +210,11 @@ class MembersController extends AppController
             return;
         }
 
-        $daysBeforeToday = $this->Members->settingsFilters['new-members']['daysBeforeToday'];
-        $newMembersDate = date_format(new \DateTime("- $daysBeforeToday days"), 'd/m/Y');
+        $dateModifier = $this->Members->settingsFilters['newMembers']['dateModifier'];
+        $newMembersDate = date_format(new \DateTime($dateModifier), 'd/m/Y');
 
-        $daysBeforeToday = $this->Members->settingsFilters['deactivated-members']['daysBeforeToday'];
-        $deactivatedMembersDate = date_format(new \DateTime("- $daysBeforeToday days"), 'd/m/Y');
+        $dateModifier = $this->Members->settingsFilters['deactivatedMembers']['dateModifier'];
+        $deactivatedMembersDate = date_format(new \DateTime($dateModifier), 'd/m/Y');
 
         $this->set(compact('members', 'newMembersDate', 'deactivatedMembersDate'));
         $this->set('_serialize', ['members']);

--- a/src/Model/Behavior/GrowthStatisticsBehavior.php
+++ b/src/Model/Behavior/GrowthStatisticsBehavior.php
@@ -1,71 +1,123 @@
 <?php
-
 namespace App\Model\Behavior;
 
+use Cake\Core\Exception\Exception;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 
 class GrowthStatisticsBehavior extends Behavior
 {
-	public function calculateGrowth($finalValue, $startValue) {
-		if ($startValue <= 0) {
-			return 100;
-		}
-		if (is_numeric($finalValue) && is_numeric($startValue)) {
-			return (($finalValue - $startValue) / $startValue) * 100;
-		}
-		return -1;
-	}
+    /**
+     * Calculate growth of a final value in relation to a start value.
+     *
+     * @param float $finalValue Number representing the final state
+     * @param float $startValue Number representing the original state
+     * @return float Number representing the growth of the final state in relation to the original state
+     */
+    public function calculateGrowth($finalValue, $startValue)
+    {
+        if ($startValue <= 0) {
+            return 100;
+        }
+        if (is_numeric($finalValue) && is_numeric($startValue)) {
+            return (($finalValue - $startValue) / $startValue) * 100;
+        }
+        return -1;
+    }
+    
+    /**
+     * Compare the number of results of a query in a certain date ('referenceDate')
+     * to the number of results in previous dates (specified in array 'dates').
+     *
+     * @example Param $options must have an array with key 'stats':
+     *  $options = [ 'stats' => [
+     *      'field' => 'Members.created'        (mandatory to assign a field to be compared)
+     *      'customFinder' => 'newMembers'      (default: from $query)
+     *      'referenceDate' => 'now'            (default: 'now')
+     *      'dates' => ["-1 month", "-1 year"]  (default: null. Format: strtotime string)
+     *  ] ];
+     *
+     * @example Result array $stats will have an array in the following format:
+     *  $stats = [
+     *      'reference' => [
+     *          "count" => 125,             (number of results of the query)
+     *          "growth" => 0,              (percentage from 0-100 in which reference's count grew)
+     *          "query" => Query object     (used to gather these results)
+     *      ],
+     *      '-1 month' => [
+     *          "count" => 100,
+     *          "growth" => 25,
+     *          "query" => Query object
+     *      ]
+     *  ];
+     *
+     * @param \Cake\ORM\Query $query Query
+     * @param array $options Query options
+     * @return array Containing key 'reference' and keys with the param 'dates'.
+     *      For each key, the value is an array with 'count', 'growth', and 'query'
+     */
+    public function findCountGrowth(Query $query, array $options)
+    {
+        if (!array_key_exists("stats", $options) || !array_key_exists("field", $options['stats'])) {
+            throw new Exception("Statistics not available with the requested parameters.");
+        }
 
-	// As options:
-	// stats
-	//   field => 'created'
-	//   referenceDate => 'today'
-	//   dates => ["-1 month", "-1 year"]
-	public function findCountGrowth(Query $query, array $options)
-	{
+        $stats = [];
+        $field = $options['stats']['field'];
+        $customFinder = (array_key_exists("customFinder", $options['stats']) ? $options['stats']['customFinder'] : null);
 
-		$stats = array();
+        // Growth reference data
+        if (array_key_exists("referenceDate", $options['stats'])) {
+            $referenceDate = new \DateTime($options['stats']['referenceDate']);
+        } else {
+            $referenceDate = new \DateTime();
+        }
 
-		if ($options['stats'] && $options['stats']['field'] && $options['stats']['dates']) {
-			$field = $options['stats']['field'];
+        $referenceQuery = (clone $query);
+        if ($customFinder) {
+            $referenceQuery = $referenceQuery->find($customFinder, [ 'referenceDate' => $referenceDate]);
+        } else {
+            $referenceQuery = $referenceQuery->where([
+                $field . ' <= ' => $referenceDate
+            ]);
+        }
 
-			// Growth reference data
-			if ($options['stats']['referenceDate']) {
-				$referenceDate = new \DateTime($options['stats']['referenceDate']);
-			}
-			else {
-				$referenceDate = new \DateTime();
-			}
-			
-			$referenceDateFormatted = date_format($referenceDate, 'Y-m-d');
+        $referenceCount = $referenceQuery->count();
 
-			$referenceQuery = $query->where([
-				$field . ' <= ' => $referenceDateFormatted
-			]);
-			$referenceCount = $referenceQuery->count();
-			$stats["reference"] = [
-				"count" => $referenceCount,
-				"growth" => 0,
-				"data" => $referenceQuery->toArray()
-			];			
+        $stats["reference"] = [
+            "count" => $referenceCount,
+            "growth" => 0,
+            "query" => $referenceQuery
+        ];
 
-			// Comparisons
-			foreach ($options['stats']['dates'] as $gDate) {
-				$comparisonDate = date_add($referenceDate, date_interval_create_from_date_string($gDate));
+        if (!$options['stats']['dates']) {
+            return $stats;
+        }
 
-				$dateQuery = $query->where([
-					$field . ' <= ' => date_format($comparisonDate, 'Y-m-d')
-				]);
+        // Growth comparisons
+        foreach ($options['stats']['dates'] as $dateModifier) {
+            $comparisonDate = clone $referenceDate;
+            $comparisonDate->modify($dateModifier);
 
-				$count = $dateQuery->count();
-				$stats[$gDate] = [
-					"count" => $count,
-					"growth" => $this->calculateGrowth($referenceCount, $count),
-					"data" => $dateQuery->toArray()
-				];
-			}
-		}
-	    return $stats;
-	}
+            $dateQuery = (clone $query);
+            if ($customFinder) {
+                $dateQuery = $dateQuery->find($customFinder, [
+                    'referenceDate' => $comparisonDate
+                ]);
+            } else {
+                $dateQuery = $dateQuery->where([
+                    $field . ' <= ' => $comparisonDate
+                ]);
+            }
+
+            $count = $dateQuery->count();
+            
+            $stats[$dateModifier] = [
+                "count" => $count,
+                "growth" => $this->calculateGrowth($referenceCount, $count),
+                "query" => $dateQuery
+            ];
+        }
+        return $stats;
+    }
 }

--- a/src/Template/Admin/Dashboards/index.ctp
+++ b/src/Template/Admin/Dashboards/index.ctp
@@ -42,7 +42,7 @@
         <div class="col-lg-3">
             <div class="ibox float-e-margins">
                 <div class="ibox-title">
-                    <span class="label label-info pull-right"><?= __('Annual') ?></span>
+                    <span class="label label-success pull-right"><?= __('Total') ?></span>
                     <h5><?= __('Re-registration rate') ?></h5>
                 </div>
                 <div class="ibox-content">
@@ -91,7 +91,10 @@
         <div class="col-lg-4">             
             <div class="ibox float-e-margins">
                 <div class="ibox-title">
-                    <h5><?= __('New members this month') ?></h5>
+                    <h5>
+                        <?= __('New members this month') ?>
+                        <span class="label label-info pull-right"><?= __('Monthly') ?></span>
+                    </h5>
                     <div class="ibox-tools">
                         <a class="collapse-link">
                             <i class="fa fa-chevron-up"></i>
@@ -108,11 +111,21 @@
                             <small><?= __('members') ?></small>
                         </div>
                         <div class="col-sm-8">
-                            <div class="row">
-                                <div class="stat-percent font-bold text-navy"><?= number_format($newMembersGrowth['-1 month']['growth'], 0) ?>%  <i class="fa fa-level-up"></i> <small> <?= __('last month') ?></small></div>
-                            </div>
-                            <div class="row">
-                                <div class="stat-percent font-bold text-info"><?= number_format($newMembersGrowth['-1 month']['growth'], 0) ?>%  <i class="fa fa-level-up"></i> <small> <?= __('last year') ?></small></div>
+                            <div class="pull-right">
+                                <?= $this->Statistics->displaySetOfStatistics(
+                                    'positive',
+                                    [
+                                        [
+                                            'percentage' => $newMembersGrowth['-1 month']['growth'],
+                                            'value' => $newMembersGrowth['-1 month']['count'],
+                                            'label' => __('last month')
+                                        ],[
+                                            'percentage' => $newMembersGrowth['-1 year']['growth'],
+                                            'value' => $newMembersGrowth['-1 year']['count'],
+                                            'label' => __('last year')
+                                        ]
+                                    ]
+                                ); ?>
                             </div>
                         </div>
                     </div>
@@ -167,9 +180,11 @@
         <div class="col-lg-4">             
             <div class="ibox float-e-margins">
                 <div class="ibox-title">
-                    <h5><?= __('Soon to expire') ?></h5>
+                    <h5>
+                        <?= __('Soon to be deactivated') ?>
+                        <span class="label label-info pull-right"><?= __('Monthly') ?></span>
+                    </h5>
                     <div class="ibox-tools">
-                        <a class="text-navy"><i class="fa fa-file-excel-o text-navy"></i><span class="sr-only"><?= __('Export') ?></span></a>
                         <a class="collapse-link">
                             <i class="fa fa-chevron-up"></i>
                         </a>
@@ -179,24 +194,36 @@
                     </div>
                 </div>
                 <div class="ibox-content">
+                    <?php 
+                    $arraySoonToDeactivateMembers = $soonToDeactivateMembers->toArray();
+                    ?>
                     <div class="row">
-                        <div class="col-sm-6 col-md-4">
-                            <h1 class="no-margins">15</h1>
+                        <div class="col-sm-6 col-md-3">
+                            <h1 class="no-margins"><?= $soonToDeactivateGrowth['reference']['count'] ?></h1>
                             <small><?= __('members') ?></small>
                         </div>
-                        <div class="col-sm-6 col-md-4">
-                            <small><strong>8</strong> <?= __('in 1st call') ?></small><br>
-                            <small><strong>2</strong> <?= __('in 2nd call') ?></small><br>
-                            <small><strong>5</strong> <?= __('in 3rd call') ?></small>
+                        <div class="col-sm-6 col-md-4 text-center">
+                            <small><strong><?= count($arraySoonToDeactivateMembers[1]) ?></strong> <?= __('in 1st call') ?></small><br>
+                            <small><strong><?= count($arraySoonToDeactivateMembers[2]) ?></strong> <?= __('in 2nd call') ?></small><br>
+                            <small><strong><?= count($arraySoonToDeactivateMembers[3]) ?></strong> <?= __('in 3rd call') ?></small>
                         </div>
-                        <div class="col-sm-12 col-md-4">
-                            <div class="row">
-                                <div class="stat-percent font-bold text-navy">2% <i class="fa fa-level-up"></i> <small> <?= __('last month') ?></small></div>
+                        <div class="col-sm-12 col-md-5">
+                            <div class="pull-right">
+                                <?= $this->Statistics->displaySetOfStatistics(
+                                    'negative',
+                                    [
+                                        [
+                                            'percentage' => $soonToDeactivateGrowth['-1 month']['growth'],
+                                            'value' => $soonToDeactivateGrowth['-1 month']['count'],
+                                            'label' => __('last month')
+                                        ],[
+                                            'percentage' => $soonToDeactivateGrowth['-1 year']['growth'],
+                                            'value' => $soonToDeactivateGrowth['-1 year']['count'],
+                                            'label' => __('last year')
+                                        ]
+                                    ]
+                                ); ?>
                             </div>
-                            <div class="row">
-                                <div class="stat-percent font-bold text-info">4% <i class="fa fa-level-up"></i> <small> <?= __('last year') ?></small></div>
-                            </div>
-
                         </div>
                     </div>
                 </div>
@@ -221,13 +248,16 @@
                         </thead>
                         <tbody>
                             <?php
-                            foreach ($newMembers as $member):
+                            $callColors = [ 1 => 'text-info', 2 => '', 3 => 'text-danger'];
+                            for ($call = 1; $call <= 3; $call++):
+                                $members = $arraySoonToDeactivateMembers[$call];
+                                foreach($members as $member):
                             ?>
                                 <tr>
                                     <td class="text-center">
-                                        <small>
+                                        <small class="<?= $callColors[$call] ?>">
                                             <i class="fa fa-calendar hidden-xs"></i>
-                                            <?= date_format($member->created, 'd/m') ?>
+                                            <?= date_format($member->memberships[0]->expires_on, 'd/m') ?>
                                         </small>
                                     </td>
                                     <td>
@@ -242,12 +272,12 @@
                                         </small>
                                     </td>
                                     <td class="text-center">
-                                        <small class="text-info">#2</small>
-                                        <!-- navy danger -->
+                                        <small class="<?= $callColors[$call] ?>">#<?= $call ?></small>
                                     </td>
                                 </tr>
                             <?php
-                            endforeach;
+                                endforeach;
+                            endfor;
                             ?>
                         </tbody>
                     </table>
@@ -258,7 +288,10 @@
         <div class="col-lg-4">
             <div class="ibox float-e-margins">
                 <div class="ibox-title">
-                    <h5><?= __('Recently expired') ?></h5>
+                    <h5>
+                        <?= __('Recently deactivated') ?>
+                        <span class="label label-info pull-right"><?= __('Monthly') ?></span>
+                    </h5>
                     <div class="ibox-tools">
                         <a class="collapse-link">
                             <i class="fa fa-chevron-up"></i>
@@ -271,22 +304,29 @@
                 <div class="ibox-content">
                     <div class="row">
                         <div class="col-sm-4">
-                            <h1 class="no-margins"><?= $metrics['numRecentlyDeactivatedMembers'] ?></h1>
+                            <h1 class="no-margins"><?= $recentlyDeactivatedGrowth['reference']['count'] ?></h1>
                             <small><?= __('members') ?></small>
                         </div>
                         <div class="col-sm-8">
-
-                            <div class="row">
-                                <div class="stat-percent font-bold text-navy">2% <i class="fa fa-level-up"></i> <small> <?= __('last month') ?></small></div>
-                            </div>
-                            <div class="row">
-                                <div class="stat-percent font-bold text-info">44% <i class="fa fa-level-up"></i> <small> <?= __('last year') ?></small></div>
-
+                            <div class="pull-right">
+                                <?= $this->Statistics->displaySetOfStatistics(
+                                    'negative',
+                                    [
+                                        [
+                                            'percentage' => $recentlyDeactivatedGrowth['-1 month']['growth'],
+                                            'value' => $recentlyDeactivatedGrowth['-1 month']['count'],
+                                            'label' => __('last month')
+                                        ],[
+                                            'percentage' => $recentlyDeactivatedGrowth['-1 year']['growth'],
+                                            'value' => $recentlyDeactivatedGrowth['-1 year']['count'],
+                                            'label' => __('last year')
+                                        ]
+                                    ]
+                                ); ?>
                             </div>
                         </div>
                     </div>
-                </div>
-                
+                </div>                
                 <div class="ibox-content table-responsive">
                     <button class="btn btn-primary btn-block m-t"><i class="fa fa-file-excel-o"></i> <?= __('Export') ?></button>
                     <table class="table table-hover no-margins">

--- a/src/Template/Admin/Members/add_edit_common.ctp
+++ b/src/Template/Admin/Members/add_edit_common.ctp
@@ -155,10 +155,9 @@
                             <fieldset class="form-horizontal">
                                 <div id="groupMembership">
                                     <?php
-                                        $input_options = [
+                                        $inputOptions = [
                                             "minYear" => date('Y') - 3,
                                             "maxYear" => date('Y') + 60,
-                                            "default" => $defaultMembershipDate,
                                             "day"=> [
                                                 "class" => "form-control"
                                             ],"month"=> [
@@ -171,6 +170,13 @@
                                                 "class" => "hide"
                                             ]
                                         ];
+
+                                        $startsOnOptions = $inputOptions;
+
+                                        $expiresOnOptions = array_merge_recursive(
+                                            $inputOptions,
+                                            ["default" => $membershipDefaultExpiration]
+                                        );
                                     ?>
                                     
                                     <?php
@@ -187,9 +193,16 @@
                                             </div>
 
                                             <div class="form-group form-inline">
-                                                <label class="col-sm-2 control-label"><?= __('Expires on') ?>:</label>
+                                                <label class="col-sm-2 control-label"><?= __('Initial date') ?>:</label>
                                                 <div class="col-sm-10">
-                                                    <?php  echo $this->Form->input("memberships.0.expires_on", $input_options); ?>
+                                                    <?php  echo $this->Form->input("memberships.0.starts_on", $startsOnOptions); ?>
+                                                </div>
+                                            </div>
+
+                                            <div class="form-group form-inline">
+                                                <label class="col-sm-2 control-label"><?= __('Final date') ?>:</label>
+                                                <div class="col-sm-10">
+                                                    <?php  echo $this->Form->input("memberships.0.expires_on", $expiresOnOptions); ?>
                                                 </div>
                                             </div>
                                         </div>
@@ -208,9 +221,16 @@
                                             </div>
 
                                             <div class="form-group form-inline">
+                                                <label class="col-sm-2 control-label"><?= __('Initial date') ?>:</label>
+                                                <div class="col-sm-10">
+                                                    <?php  echo $this->Form->input("memberships.0.starts_on", $startsOnOptions); ?>
+                                                </div>
+                                            </div>
+
+                                            <div class="form-group form-inline">
                                                 <label class="col-sm-2 control-label"><?= __('Expires on') ?>:</label>
                                                 <div class="col-sm-10">
-                                                    <?php  echo $this->Form->input("memberships.$i.expires_on", $input_options); ?>
+                                                    <?php  echo $this->Form->input("memberships.$i.expires_on", $expiresOnOptions); ?>
                                                 </div>
                                             </div>
                                         </div>

--- a/src/Template/Admin/Members/import.ctp
+++ b/src/Template/Admin/Members/import.ctp
@@ -64,7 +64,7 @@
                 </div>
 
                 <div class="col-sm-offset-2 col-sm-10 alert alert-warning">
-                    <?= __('Note: A membership will automatically be created for all members. If column "Expires on" is not defined, default date (1 year from today) will be applied. You can change it for each member later on.') ?>
+                    <?= __('Note: A membership will automatically be created for all members. If columns "Starts on" and "Expires on" are not defined, default dates (today and 1 year from today) will be applied. You can change it for each member later on.') ?>
                 </div>
 
                 <div class="form-group">

--- a/src/View/Helper/StatisticsHelper.php
+++ b/src/View/Helper/StatisticsHelper.php
@@ -1,0 +1,55 @@
+<?php
+namespace App\View\Helper;
+
+use Cake\View\Helper;
+use Cake\View\StringTemplateTrait;
+
+class StatisticsHelper extends Helper
+{
+    /**
+     * Get HTML to display a single row of statistics
+     *
+     * @param string $type 'positive'|'negative' - whether a percentage > 0 indicates something positive or negative
+     * @param float $percentage Number from 0-100
+     * @param float $value Number that generated the percentage
+     * @param string $label Label to be identify the meaning of these values
+     * @return string HTML code
+     */
+    public function displaySingleStatistics($type, $percentage, $value, $label)
+    {
+        $percentage = number_format($percentage, 0);
+
+        if ((($type == "positive") && ($percentage < 0)) || (($type == "negative") && ($percentage > 0))) {
+            $textColor = "text-danger";
+            $icon = "fa-level-up";
+        } else {
+            $textColor = "text-navy";
+            $icon = "fa-level-down";
+        }
+
+        $html = "<div class='display-table-row stat-percent font-bold $textColor'>";
+        $html .= "	<div class='display-table-cell text-right'>" . $percentage . "%</div>";
+        $html .= "	<div class='display-table-cell'><i class='fa $icon'></i></div>";
+        $html .= "	<div class='display-table-cell'><small>$label</small></div>";
+        $html .= "	<div class='display-table-cell'><small>($value)</small></div>";
+        $html .= "</div>";
+        return $html;
+    }
+
+    /**
+     * Get HTML to display a set of statistics in a table layout
+     *
+     * @param string $type 'positive'|'negative' - whether a percentage > 0 indicates something positive or negative
+     * @param array $statistics Keys: 'percentage', value', 'label'
+     * @return string HTML code
+     */
+    public function displaySetOfStatistics($type, array $statistics)
+    {
+        $html = "<div class='row stat-table'>";
+        foreach ($statistics as $stat) {
+            $html .= $this->displaySingleStatistics($type, $stat['percentage'], $stat['value'], $stat['label']);
+        }
+        $html .= "</div>";
+        return $html;
+    }
+}

--- a/tamarin.sql
+++ b/tamarin.sql
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS `members` (
 CREATE TABLE IF NOT EXISTS `memberships` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
   `member_id` int(11) NOT NULL,
+  `starts_on` date NOT NULL,
   `expires_on` date NOT NULL,
   `created` date NOT NULL,
   `modified` datetime DEFAULT NULL,

--- a/webroot/css/custom.css
+++ b/webroot/css/custom.css
@@ -48,3 +48,20 @@ table {
 .table-responsive > .table > tbody > tr > td, .table-responsive > .table > tbody > tr > th, .table-responsive > .table > tfoot > tr > td, .table-responsive > .table > tfoot > tr > th, .table-responsive > .table > thead > tr > td, .table-responsive > .table > thead > tr > th {
     white-space: normal;
 }
+.display-table {
+    display: table;
+}
+.display-table-row {
+    display: table-row;
+}
+.display-table-cell {
+    display: table-cell;
+}
+
+/* Statistics */
+.stat-table .stat-percent {
+    float: none;
+}
+.stat-table .stat-percent .display-table-cell {
+    padding: 0 2px;
+}


### PR DESCRIPTION
https://github.com/LordAlexWorks/tamarin/issues/30 Membership initial date
- [x] Added an initial date to the memberships, so that statistics can be generated correctly
- [x] Initial date is also sent to mailchimp

<img width="505" alt="dashboard_initial_date" src="https://cloud.githubusercontent.com/assets/2302126/16109655/5dcb29f8-3380-11e6-982e-a4de0920ddc7.png">
## Database changes

Already executed in heroku's database.

``` sql
ALTER TABLE `memberships` ADD `starts_on` DATE NOT NULL AFTER `member_id` ;
UPDATE `memberships` SET `starts_on`=  DATE_SUB(`expires_on`, INTERVAL 1 YEAR);
```

https://github.com/LordAlexWorks/tamarin/issues/24 Dashboard
- [x] Finished statistics behavior to generate growth comparisons for any queries and dates
- [x] Generated statistics for:
  - total numbers of registered members
  - new members this month (compared to last month and last year)
  - soon to be expire members this month (1st call, 2nd call, 3rd call compared to last month and last year) 
  - new expired this month (compared to last month and last year) : list and numbers

Still missing:
- [ ] re-registration rate data
- [ ] link to export queries
- [ ] Most common job title
- [ ] Average age

<img width="895" alt="dashboard_update_real_data" src="https://cloud.githubusercontent.com/assets/2302126/16109631/31996e08-3380-11e6-8597-2e4f3f7fd248.png">
